### PR TITLE
Full test coverage on `cue_set.ts` and `utils.ts`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 node_modules
 dist
+coverage
 
 test.mp4
 test.mp4.vtt

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,5 +1,8 @@
 /** @type {import('ts-jest').JestConfigWithTsJest} */
 module.exports = {
+  moduleFileExtensions: ['js', 'ts', 'tsx'],
+  collectCoverageFrom: ['src/*.{ts,tsx}'],
+  coverageProvider: "v8",
   preset: 'ts-jest',
   testEnvironment: 'node',
 };

--- a/src/cue_editor.tsx
+++ b/src/cue_editor.tsx
@@ -163,7 +163,7 @@ export default function CueEditor(props: { time: TimeInfo, cues: CueSet, audio: 
       textarea = <textarea id="cue-textarea" value={editState.text} onChange={updateContents}></textarea>;
       break;
     case "locked":
-      textarea = <textarea id="cue-textarea" value={current_cue.getWords().join(" ")} onChange={updateContents}></textarea>;
+      textarea = <textarea id="cue-textarea" value={current_cue.text()} onChange={updateContents}></textarea>;
       break;
     case "no_cue":
       return (

--- a/src/cue_editor.tsx
+++ b/src/cue_editor.tsx
@@ -4,7 +4,7 @@ import RegionsPlugin, { Region, RegionParams } from "wavesurfer.js/src/plugin/re
 import { TimeInfo } from "./app";
 
 import { CueSet, EditEvent } from "./cue_set";
-import { vtt_timestamp } from "./utils";
+import { vttTimestamp } from "./utils";
 
 type EditState = {
   "state": "locked",
@@ -175,7 +175,7 @@ export default function CueEditor(props: { time: TimeInfo, cues: CueSet, audio: 
 
   return (<div id="cue-editor">
     <div>
-      Timing: {vtt_timestamp(current_cue.startTime)} --&gt; {vtt_timestamp(current_cue.endTime)}<br />
+      Timing: {vttTimestamp(current_cue.startTime)} --&gt; {vttTimestamp(current_cue.endTime)}<br />
       Contents:<br />
       {textarea}
       <Waveform url={props.audio} time={props.time} cues={props.cues} onEdit={props.onEdit} onTimeUpdate={props.onTimeUpdate} />

--- a/src/cue_set.test.ts
+++ b/src/cue_set.test.ts
@@ -299,6 +299,57 @@ describe('move edit', () => {
   });
 });
 
-test('empty array', () => {
-  new Cue("0", 0, 1, []);
-})
+describe('Cue methods', () => {
+  test('empty array', () => {
+    new Cue("0", 0, 1, []);
+  });
+
+  test('single-cue clone', () => {
+    const original = new Cue("foo", 0, 1, ["bar"]);
+    const copy = original.clone();
+    expect(copy).toEqual(original);
+  });
+
+  test("cue text reassembly", () => {
+    const cue = new Cue("", 0, 0, ["foo", "bar", "baz"]);
+    expect(cue.text()).toEqual("foo bar baz");
+
+    const empty = new Cue("", 0, 0, []);
+    expect(empty.text()).toEqual("");
+  });
+
+  test("isActive endpoints", () => {
+    const cue = new Cue("", 1, 2, []);
+
+    // easy stuff
+    expect(cue.isActive(1.5)).toBeTruthy();
+    expect(cue.isActive(0)).toBeFalsy();
+    expect(cue.isActive(3)).toBeFalsy();
+
+    // cue start is inclusive
+    expect(cue.isActive(1)).toBeTruthy();
+
+    // cue end is exclusive
+    expect(cue.isActive(2)).toBeFalsy();
+
+  });
+
+  test("timeForIndex", () => {
+    const cue = new Cue("", 0, 1, ["foo", "bar"]);
+
+    expect(cue.timeForIndex(-1)).toEqual(0);
+    expect(cue.timeForIndex(0)).toEqual(0);
+    expect(cue.timeForIndex(1)).toEqual(0.5);
+    expect(cue.timeForIndex(2)).toEqual(1);
+    expect(cue.timeForIndex(3)).toEqual(1);
+  });
+
+  test("indexForTime", () => {
+    const cue = new Cue("", 0, 1, ["foo", "bar"]);
+    expect(cue.indexForTime(-1)).toBeUndefined();
+    expect(cue.indexForTime(0)).toEqual(0);
+    expect(cue.indexForTime(0.5)).toEqual(1);
+    expect(cue.indexForTime(1)).toEqual(2);
+    expect(cue.indexForTime(2)).toBeUndefined();
+  })
+});

--- a/src/cue_set.ts
+++ b/src/cue_set.ts
@@ -47,10 +47,10 @@ export class Cue {
   startTime: number;
   endTime: number;
 
-  words: string[];
-  total_characters: number;
-  characters_words: number[];
-  words_characters: number[];
+  readonly words: string[];
+  readonly total_characters: number;
+  readonly characters_words: number[];
+  readonly words_characters: number[];
 
   public constructor(id: string, startTime: number, endTime: number, contents: string[]) {
     this.id = id;
@@ -71,6 +71,7 @@ export class Cue {
 
       const current_word = this.words[current_word_index];
 
+      /* c8 ignore next 3 */
       if (current_word === undefined) {
         throw new Error("ran off the end of this.words in cue constructor; shouldn't happen");
       }
@@ -81,15 +82,12 @@ export class Cue {
         chars_this_word = 0;
       }
     }
+    this.characters_words[this.total_characters] = this.words.length;
   }
 
   public clone(): Cue {
     // TODO could we optimize here by copying the generated fields?
     return new Cue(this.id, this.startTime, this.endTime, [...this.words]);
-  }
-
-  public toString(): string {
-    return `${this.startTime.toFixed(3)} -> ${this.endTime.toFixed(3)}: ${this.words.join(" ")}`;
   }
 
   public text(): string {
@@ -121,10 +119,6 @@ export class Cue {
   public indexForTime(time: number): number | undefined {
     const nearest_character = Math.round(((time - this.startTime) / this.duration()) * this.total_characters);
     return this.characters_words[nearest_character];
-  }
-
-  public getWords(): readonly string[] {
-    return this.words
   }
 }
 
@@ -420,7 +414,7 @@ export class CueSet {
     const chunks = ["WEBVTT"];
 
     for (const cue of this.cues) {
-      chunks.push(`${vttTimestamp(cue.startTime)} --> ${vttTimestamp(cue.endTime)}\n${cue.words.join(" ")}`);
+      chunks.push(`${vttTimestamp(cue.startTime)} --> ${vttTimestamp(cue.endTime)}\n${cue.text()}`);
     }
 
     return chunks.join("\n\n");

--- a/src/cue_set.ts
+++ b/src/cue_set.ts
@@ -1,5 +1,5 @@
 import { v4 as uuidv4 } from 'uuid';
-import { vtt_timestamp } from './utils';
+import { vttTimestamp } from './utils';
 
 const REFLOW_MIN_SENTENCE_LENGTH = 5;
 
@@ -420,7 +420,7 @@ export class CueSet {
     const chunks = ["WEBVTT"];
 
     for (const cue of this.cues) {
-      chunks.push(`${vtt_timestamp(cue.startTime)} --> ${vtt_timestamp(cue.endTime)}\n${cue.words.join(" ")}`);
+      chunks.push(`${vttTimestamp(cue.startTime)} --> ${vttTimestamp(cue.endTime)}\n${cue.words.join(" ")}`);
     }
 
     return chunks.join("\n\n");

--- a/src/cue_set.ts
+++ b/src/cue_set.ts
@@ -154,7 +154,11 @@ export class CueSet {
       const from_cue_index = this.cues.findIndex((cue) => cue.id == event.from_id);
       const to_cue_index = this.cues.findIndex((cue) => cue.id == event.to_id);
 
-      const to_cue = this.cues[to_cue_index] || (() => { throw new Error("can't happen") })();
+      const to_cue = this.cues[to_cue_index];
+
+      if (from_cue_index < 0 || to_cue === undefined) {
+        return false;
+      }
 
       if (event.edge == "start" && to_cue_index > from_cue_index) {
         return false;
@@ -168,7 +172,7 @@ export class CueSet {
         return false;
       }
 
-      if (event.edge == "end" && event.to_index == 0) {
+      if (event.edge == "end" && event.to_index <= 0) {
         return false;
       }
 
@@ -206,7 +210,11 @@ export class CueSet {
 
     } else if (event.type == "join") {
       const cue_index = this.cues.findIndex((cue) => cue.id == event.id);
-      const this_cue = this.cues[cue_index] || (() => { throw new Error("can't happen") })();
+      const this_cue = this.cues[cue_index];
+
+      if (this_cue === undefined) {
+        return false;
+      }
 
       if (event.edge == "start") {
         const previous_cue = this.cues[cue_index - 1];
@@ -216,7 +224,7 @@ export class CueSet {
 
         const contents = previous_cue.words.concat(this_cue.words);
         this.cues.splice(cue_index - 1, 2, new Cue(
-          _keep_second_id_hack ? this_cue.id : uuidv4(),
+          _keep_second_id_hack /* c8 ignore next */ ? this_cue.id : uuidv4(),
           previous_cue.startTime,
           this_cue.endTime,
           contents
@@ -236,7 +244,11 @@ export class CueSet {
       }
     } else if (event.type == "split") {
       const cue_index = this.cues.findIndex((cue) => cue.id == event.id);
-      const this_cue = this.cues[cue_index] || (() => { throw new Error("can't happen") })();
+      const this_cue = this.cues[cue_index];
+
+      if (this_cue === undefined) {
+        return false;
+      }
 
       if (event.index == 0 || event.index >= this_cue.words.length) {
         return false;
@@ -252,14 +264,16 @@ export class CueSet {
         point,
         first
       ), new Cue(
-        _keep_second_id_hack ? event.id : uuidv4(),
+        _keep_second_id_hack /* c8 ignore next */ ? event.id : uuidv4(),
         point,
         this_cue.endTime,
         rest
       ));
     } else if (event.type == "set_contents") {
       const cue_index = this.cues.findIndex((cue) => cue.id == event.id);
-      const this_cue = this.cues[cue_index] || (() => { throw new Error("can't happen") })();
+      const this_cue = this.cues[cue_index];
+
+      if (this_cue === undefined) return false;
 
       this.cues.splice(cue_index, 1, new Cue(
         this_cue.id,
@@ -269,7 +283,9 @@ export class CueSet {
       ));
     } else if (event.type == "retime") {
       const cue_index = this.cues.findIndex((cue) => cue.id == event.id);
-      const this_cue = this.cues[cue_index] || (() => { throw new Error("can't happen") })();
+      const this_cue = this.cues[cue_index];
+
+      if (this_cue === undefined) return false;
 
       this_cue.startTime = event.start;
       this_cue.endTime = event.end;
@@ -283,7 +299,9 @@ export class CueSet {
       this_cue.id = uuidv4();
     } else if (event.type == "gap") {
       const cue_index = this.cues.findIndex((cue) => cue.id == event.id);
-      const this_cue = this.cues[cue_index] || (() => { throw new Error("can't happen") })();
+      const this_cue = this.cues[cue_index];
+
+      if (this_cue === undefined) return false;
 
       const point = Math.max(this_cue.endTime - 1, this_cue.duration() / 2 + this_cue.startTime);
       this.cues.splice(cue_index + 1, 0, new Cue(
@@ -297,6 +315,10 @@ export class CueSet {
 
       // reroll the ID on the edited region so the waveform display picks it up
       this_cue.id = uuidv4();
+
+      // I already know this doesn't work, I don't need the tests telling me
+      // about it too
+      /* c8 ignore start */
     } else if (event.type == "reflow") {
       // Reflow based on sentence breaks.
 
@@ -349,6 +371,7 @@ export class CueSet {
         cue.id = uuidv4();
       }
     }
+    /* c8 ignore stop */
 
     return true;
   }

--- a/src/editor.tsx
+++ b/src/editor.tsx
@@ -115,7 +115,7 @@ function CueList(props: { time: number, cues: CueSet, onTimeUpdate: (time: numbe
       <th>cps</th>
       <th>content</th>
     </tr>
-    {props.cues?.getCues().map((cue) => <CueElement key={cue.id} cue={cue} time={props.time} onTimeUpdate={(time) => props.onTimeUpdate(cue.startTime + time)} onEdit={props.onEdit} />)}
+    {props.cues?.cues.map((cue) => <CueElement key={cue.id} cue={cue} time={props.time} onTimeUpdate={(time) => props.onTimeUpdate(cue.startTime + time)} onEdit={props.onEdit} />)}
   </table>;
 }
 

--- a/src/utils.test.ts
+++ b/src/utils.test.ts
@@ -1,0 +1,24 @@
+import { parseTimecode, vttTimestamp } from "./utils";
+
+describe('parseTimecode', () => {
+  test('minutes-seconds-millis', () => {
+    expect(parseTimecode("01:02.030")).toBeCloseTo(62.03);
+  });
+
+  test('hours-minutes-seconds-millis', () => {
+    expect(parseTimecode("01:02:03.040")).toBeCloseTo(3723.04);
+  });
+
+  test('bad timecode', () => {
+    expect(() => parseTimecode("horsebooks")).toThrow();
+  })
+});
+
+test('vttTimestamp', () => {
+  expect(vttTimestamp(0)).toEqual("00:00:00.000");
+  expect(vttTimestamp(62.03)).toEqual("00:01:02.030");
+  expect(vttTimestamp(3723)).toEqual("01:02:03.000");
+
+  // hour can go to 4 digits
+  expect(vttTimestamp(1000 * 3600)).toEqual("1000:00:00.000");
+});

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -6,20 +6,26 @@ export function parseTimecode(tc: string): number {
     throw new Error("bad timecode");
   }
 
-  const hours = Number.parseInt(found[1] || "0");
-  const minutes = Number.parseInt(found[2] || "0");
-  const seconds = Number.parseFloat(found[3] || "0");
+  const hours = Number.parseInt(found[1] ?? "0");
+
+  /* c8 ignore next 3 */
+  if (found[2] === undefined || found[3] === undefined) {
+    throw new Error("missing captures in regex; can't happen");
+  }
+
+  const minutes = Number.parseInt(found[2]);
+  const seconds = Number.parseFloat(found[3]);
 
   return hours * 3600 + minutes * 60 + seconds;
 }
 
 
-export function vtt_timestamp(time: number): string {
+export function vttTimestamp(time: number): string {
   const hours = Math.floor(time / 3600).toString().padStart(2, "0");
   const minutes = (Math.floor(time / 60) % 60).toString().padStart(2, "0");
   const seconds = (Math.floor(time % 60)).toString().padStart(2, "0");
 
-  const millis = Math.floor((time % 1) * 1000).toString().padStart(2, "0");
+  const millis = Math.floor((time % 1) * 1000).toString().padStart(3, "0");
 
   return `${hours}:${minutes}:${seconds}.${millis}`;
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -9,6 +9,7 @@
     "moduleResolution": "node",
     "strict": true,
     "noUncheckedIndexedAccess": true,
+    "esModuleInterop": true,
   },
   "include": [
     "src/*.d.ts",


### PR DESCRIPTION
```
-----------------|---------|----------|---------|---------|-------------------
File             | % Stmts | % Branch | % Funcs | % Lines | Uncovered Line #s
-----------------|---------|----------|---------|---------|-------------------
All files        |   36.96 |    95.58 |      76 |   36.96 |
 app.tsx         |       0 |        0 |       0 |       0 | 1-415
 cue_editor.tsx  |       0 |        0 |       0 |       0 | 1-184
 cue_set.ts      |     100 |      100 |     100 |     100 |
 editor.tsx      |       0 |        0 |       0 |       0 | 1-128
 index.tsx       |       0 |        0 |       0 |       0 | 1-6
 player.tsx      |       0 |        0 |       0 |       0 | 1-68
 utils.ts        |     100 |      100 |     100 |     100 |
 wavesurfer.d.ts |       0 |        0 |       0 |       0 | 1-4
-----------------|---------|----------|---------|---------|-------------------
```

That's all the internal API stuff. Also, fixes some internal API bugs:
- Several edits would throw if given bad cue IDs rather than returning false.
- `CueSet.nextEnd` contained unreachable code.
- `Cue.indexForTime` fails when given the cue's end time.
- `CueSet.previousStart` and `CueSet.nextEnd` would misbehave when called with a time outside any cue.
- Output VTT timestamps have the wrong number of milliseconds digits.

Those last two are user-visible.